### PR TITLE
FIX Handle modules that are checked out as tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,25 @@ on:
     - cron: '0 14 * * 2'
 
 jobs:
-  ci:
+  build:
     name: CI
-    # Only run cron on the silverstripe account
-    if: (github.event_name == 'schedule' && github.repository_owner == 'silverstripe') || (github.event_name != 'schedule')
-    uses: silverstripe/gha-ci/.github/workflows/ci.yml@v1
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Checkout code
+      uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2.4.2
+
+    - name: Install PHP
+      uses: shivammathur/setup-php@3eda58347216592f618bb1dff277810b6698e4ca # v2.19.1
+      with:
+        php-version: 7.4
+        tools: composer:v2
+
+    - name: Composer install
+      run: composer install
+
+    - name: PHPUnit
+      run: vendor/bin/phpunit
+
+    - name: PHP linting
+      run: vendor/bin/phpcs

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/silverstripe/framework/tests/bootstrap.php" colors="true">
+<phpunit colors="true">
     <testsuites>
         <testsuite name="Default">
             <directory>tests</directory>

--- a/tests/TranslatorTest.php
+++ b/tests/TranslatorTest.php
@@ -12,9 +12,49 @@ class TranslatorTest extends TestCase
     private const INVALID = 'INVALID';
 
     /**
+     * @dataProvider provideGetCleanBranch
+     */
+    public function testGetCleanBranch(string $branch, string $expected)
+    {
+        $actual = $this->invokeMethod('getCleanBranch', $branch);
+        $this->assertSame($expected, $actual);
+    }
+
+    public function provideGetCleanBranch()
+    {
+        return [
+            [
+                '5',
+                '5'
+            ],
+            [
+                '5.0',
+                '5.0'
+            ],
+            [
+                'invalid',
+                'invalid'
+            ],
+            [
+                '(HEAD detached at 1.2.3)',
+                '1.2'
+            ],
+            [
+                '(HEAD detached at 4.5.6-beta1)',
+                '4.5'
+            ],
+            [
+                // This is how it looks when a commit is checked out
+                '(HEAD detached at 2238396)',
+                '(HEAD detached at 2238396)'
+            ]
+        ];
+    }
+
+    /**
      * @dataProvider provideJsonEncode
-     * */
-    public function testJsonEncode(mixed $data, string $expected): void
+     */
+    public function testJsonEncode($data, string $expected): void
     {
         if ($expected === self::INVALID) {
             $this->expectException(LogicException::class);
@@ -59,7 +99,7 @@ class TranslatorTest extends TestCase
     /**
      * @dataProvider provideJsonDecode
      */
-    public function testJsonDecode(string $jsonString, mixed $expected): void
+    public function testJsonDecode(string $jsonString, $expected): void
     {
         if ($expected === self::INVALID) {
             $this->expectException(LogicException::class);
@@ -140,7 +180,7 @@ class TranslatorTest extends TestCase
         ];
     }
 
-    private function invokeMethod(string $methodName, mixed ...$args): mixed
+    private function invokeMethod(string $methodName, ...$args)
     {
         $translator = new Translator();
         $method = new ReflectionMethod($translator, $methodName);


### PR DESCRIPTION
Issue https://github.com/silverstripe/cow/issues/234

colymba/gridfield-bulk-editing-tools checks out as a tag `3.0.2` when installing recipe-kitchen-sink `4.x-dev` - This PR will attempt to switch its branch to `3.0` so that it can proceed as normal.

colymba/gridfield-bulk-editing-tools is a caret in recipe-blog `4.x-dev` - https://github.com/silverstripe/recipe-blog/blob/1/composer.json#L17 hence why the tag is installed
