### PR TITLE
FIX Handle non-strings

### DIFF
--- a/src/Translator.php
+++ b/src/Translator.php
@@ -316,7 +316,7 @@ class Translator
             if (is_array($val)) {
                 $this->recursiveRecordBlankStrings($parentKey . '-' . $key, $val);
             }
-            if ($this->isBlankString($val)) {
+            if (is_string($val) && $this->isEmpty($val)) {
                 $this->blankEnStrings[$parentKey . '-' . $key] = true;
             }
         }
@@ -328,15 +328,15 @@ class Translator
             if (is_array($val)) {
                 $this->recursiveRemoveBlankStrings($parentKey . '-' . $key, $val);
             }
-            if ($this->isBlankString($val) && !array_key_exists($parentKey . '-' . $key, $this->blankEnStrings)) {
+            if ($this->isEmpty($val) && !array_key_exists($parentKey . '-' . $key, $this->blankEnStrings)) {
                 unset($data[$key]);
             }
         }
     }
 
-    private function isBlankString(string $str)
+    private function isEmpty($val)
     {
-        return empty($str) && $str !== '0';
+        return empty($val) && $val !== '0';
     }
 
     /**


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/17

`$val` is often an array, since it's working inside a recursive method

Have run this code to generate - https://github.com/tractorcow-farm/silverstripe-fluent/pull/790

Release 1.0.4 when merged and ask me to manually update packagist if you're not able to yourself