### PR TITLE
FIX Get i18nTextCollector working from wget

### DIFF
--- a/src/Translator.php
+++ b/src/Translator.php
@@ -406,7 +406,7 @@ class Translator
         }
         $module = urlencode(implode(',', $modulesNames));
         $site = rtrim($this->txSite, '/');
-        $this->exec("wget --content-on-error $site/dev/tasks/i18nTextCollectorTask?flush=all&merge=1&module=$module");
+        $this->exec("wget --content-on-error $site/dev/tasks/i18nTextCollectorTask?module=$module");
     }
 
     /**


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-tx-translator/issues/13

As discovered in https://github.com/silverstripe/silverstripe-framework/pull/10816 - merge default is 1 so doesn't need to be defined

Seem like it may have been the `flush=all` bit that was messing up the wget call. It simply shouldn't be there though, there's an assumption that by the time you're calling wget you've properly setup your environment already (which includes dev/build flush=1)