### PR TITLE
FIX Handle non-array

### DIFF
--- a/src/Translator.php
+++ b/src/Translator.php
@@ -331,7 +331,7 @@ class Translator
             // Remove any keys where the value is the same as the source english value
             $contentYaml = Yaml::parse(file_get_contents($path));
             foreach (array_keys($contentYaml) as $countryCode) {
-                foreach (array_keys($contentYaml[$countryCode]) as $className) {
+                foreach (array_keys($contentYaml[$countryCode] ?? []) as $className) {
                     foreach (array_keys($contentYaml[$countryCode][$className]) as $key) {
                         $value = $contentYaml[$countryCode][$className][$key] ?? null;
                         $enValue = $enYaml['en'][$className][$key] ?? null;


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/153

I noticed that for whatever reason fluent (and queuedjobs?) threw errors at the same place because there was a null instead of an array. I was unable to debug exactly why this was happening, so I think we should just gracefully handle it.  We still ended up with a sane looking fluent PR - https://github.com/tractorcow-farm/silverstripe-fluent/pull/814