### PR TITLE
FIX Skip null values

### DIFF
--- a/src/Translator.php
+++ b/src/Translator.php
@@ -332,7 +332,7 @@ class Translator
             $contentYaml = Yaml::parse(file_get_contents($path));
             foreach (array_keys($contentYaml) as $countryCode) {
                 foreach (array_keys($contentYaml[$countryCode] ?? []) as $className) {
-                    foreach (array_keys($contentYaml[$countryCode][$className]) as $key) {
+                    foreach (array_keys($contentYaml[$countryCode][$className] ?? []) as $key) {
                         $value = $contentYaml[$countryCode][$className][$key] ?? null;
                         $enValue = $enYaml['en'][$className][$key] ?? null;
                         if ($value === $enValue) {


### PR DESCRIPTION
Avoids getting this error:

```text
PHP Fatal error:  Uncaught TypeError: array_keys(): Argument #1 ($array) must be of type array, null given in /var/www/translations-pull/vendor/silverstripe/tx-translator/src/Translator.php:335
```

We can see we've done the same thing in the parent loop, too.

## Issue
- https://github.com/silverstripe/.github/issues/234