### PR TITLE
FIX Manually read token from .transifexrc

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "symfony/process": "^4 || ^5 || ^6",
         "symfony/yaml": "^4 || ^5 || ^6",
         "symfony/dotenv": "^5 || ^6",
+        "symfony/filesystem": "^5 || ^6",
         "guzzlehttp/guzzle": "^6 || ^7"
     },
     "conflict": {

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -9,6 +9,7 @@ use Symfony\Component\Yaml\Yaml;
 use RuntimeException;
 use LogicException;
 use Symfony\Component\Console\Formatter\OutputFormatter;
+use Symfony\Component\Filesystem\Path;
 
 class Translator
 {
@@ -46,6 +47,8 @@ class Translator
 
     private ?OutputFormatter $outputFormatter = null;
 
+    private string $txToken = '';
+
     public function run()
     {
         $this->outputFormatter = new OutputFormatter(true);
@@ -80,6 +83,7 @@ class Translator
 
     private function checkEnv(): void
     {
+        $this->readTxToken();
         $txInstructions = 'Install the new go version of the client https://developers.transifex.com/docs/cli';
         try {
             $this->exec('which tx');
@@ -618,7 +622,13 @@ class Translator
 
     private function exec(string $command, ?string $cwd = null): string
     {
-        $this->log("Running $command");
+        if (str_starts_with($command, 'tx ')) {
+            $token = $this->txToken;
+            $command = "TX_TOKEN=$token $command";
+        }
+        $message = "Running $command";
+        $message = preg_replace('/TX_TOKEN=.+? tx/', 'TX_TOKEN=**** tx', $message);
+        $this->log($message);
         $process = Process::fromShellCommandline($command, $cwd);
         // set a timeout of 5 minutes - tx pull operations may take a long time
         $process->setTimeout(300);
@@ -836,5 +846,23 @@ class Translator
                 $this->recursiveKeySort($arr[$key]);
             }
         }
+    }
+
+    /**
+     * The tx binary doesn't appear to correctly read from ~/.transifexrc, even though it will correctly
+     * write to it after prompting for it if it's missing. This is a workaround to read the token and
+     * use it a TX_TOKEN environment variable, which the tx binary will use.
+     */
+    private function readTxToken(): void
+    {
+        $path = Path::canonicalize('~/.transifexrc');
+        if (!file_exists($path)) {
+            throw new RuntimeException("$path does not exist");
+        }
+        $contents = file_get_contents($path);
+        if (!preg_match('/\ntoken *= *(.+)(\n|$)/', $contents, $matches)) {
+            throw new RuntimeException("Could not get a valid token from $path");
+        }
+        $this->txToken = $matches[1];
     }
 }


### PR DESCRIPTION
There seems to be a bug in the tx binary where it won't read a previously set API token in ~/.transifexrc - there is an existing issue for this https://github.com/transifex/cli/issues/233

This PR works around this limitation by manually reading .transifexrc and passing it in as an environment variable to sub processes