### PR TITLE
DEP Require tagged version of silverstripe/supported-modules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "silverstripe/supported-modules": "dev-main",
+        "silverstripe/supported-modules": "^1",
         "symfony/console": "^4 || ^5 || ^6",
         "symfony/process": "^4 || ^5 || ^6",
         "symfony/yaml": "^4 || ^5 || ^6",


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/365

We need to use a tagged version of supported-modules in order to get the ^1.2 line of tx-translator to install on a CMS 5 site, otherwise it will be limited to the 1.1 line