### PR TITLE
Update deps and don't let CMS 6 delete localisation keys

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,11 +14,11 @@
     "require": {
         "php": "^8.1",
         "silverstripe/supported-modules": "^1",
-        "symfony/console": "^4 || ^5 || ^6",
-        "symfony/process": "^4 || ^5 || ^6",
-        "symfony/yaml": "^4 || ^5 || ^6",
-        "symfony/dotenv": "^5 || ^6",
-        "symfony/filesystem": "^5 || ^6",
+        "symfony/console": "^4 || ^5 || ^6 || ^7",
+        "symfony/process": "^4 || ^5 || ^6 || ^7",
+        "symfony/yaml": "^4 || ^5 || ^6 || ^7",
+        "symfony/dotenv": "^5 || ^6 || ^7",
+        "symfony/filesystem": "^5 || ^6 || ^7",
         "guzzlehttp/guzzle": "^6 || ^7"
     },
     "conflict": {

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -673,6 +673,7 @@ class Translator
         if ($isVerbose && !$this->versboseLogging) {
             return;
         }
+        $message = str_replace([$this->txToken, $this->githubToken], '<redacted>', $message);
         echo $this->outputFormatter->format($message) . "\n";
     }
 

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -55,22 +55,19 @@ class Translator
         $this->outputFormatter = new OutputFormatter(true);
         $this->checkEnv();
         $this->setModulePaths();
+        $this->log('Updating translations for ' . count($this->modulePaths) . ' module(s)');
         if ($this->doTransifexPullAndUpdate) {
-            $this->log('Updating translations for ' . count($this->modulePaths) . ' module(s)');
-            $this->storeJson();
-            $this->storeYaml();
+            $this->log('Starting transifex pull block');
+            $this->backupContent();
             $this->setJsonAndYmlFileTimes();
             $this->transifexPullSource();
-            $this->mergeYaml();
-            $this->removeEnglishStringsFromYamlTranslations();
-            $this->cleanYaml();
-            $this->mergeJson();
-            $this->removeEnglishStringsFromJsonTranslations();
-            $this->removeEmptyYamlFiles();
-            $this->removeEmptyJsFiles();
+            $this->mergeAndCleanContent();
         }
         if ($this->doCollectStrings) {
+            $this->log('Starting string collection block');
+            $this->backupContent();
             $this->collectStrings();
+            $this->mergeAndCleanContent();
         }
         if ($this->doTransifexPullAndUpdate) {
             $this->generateJavascript();
@@ -213,12 +210,20 @@ class Translator
     }
 
     /**
-     * Backup local json files prior to replacing local copies with transifex
+     * Backup local JSON and YAML content in memory.
+     */
+    private function backupContent(): void
+    {
+        $this->storeJson();
+        $this->storeYaml();
+    }
+
+    /**
+     * Backup local JSON files in memory
      */
     private function storeJson(): void
     {
         $this->log('Backing up local json files');
-        // Backup files prior to replacing local copies with transifex
         $this->originalJson = [];
         foreach ($this->modulePaths as $modulePath) {
             $jsPath = $this->getJSLangDirectories($modulePath);
@@ -233,7 +238,7 @@ class Translator
     }
 
     /**
-     * Backup local yaml files in memory prior to replacing local copies with transifex
+     * Backup local YAML files in memory
      */
     private function storeYaml(): void
     {
@@ -290,6 +295,21 @@ class Translator
             // pull from transifex
             $this->exec("tx pull -a -s -t -f --minimum-perc={$this->txMinimumPerc}", $modulePath);
         }
+    }
+
+    /**
+     * Merge pulled or discovered localisations into the backups to prevent data loss.
+     * Also cleans up files.
+     */
+    private function mergeAndCleanContent(): void
+    {
+        $this->mergeYaml();
+        $this->removeEnglishStringsFromYamlTranslations();
+        $this->cleanYaml();
+        $this->mergeJson();
+        $this->removeEnglishStringsFromJsonTranslations();
+        $this->removeEmptyYamlFiles();
+        $this->removeEmptyJsFiles();
     }
 
     /**


### PR DESCRIPTION
There are intentionally three commits here:

1. Update dependencies for CMS 6 compatibility
2. Make sure we backup content before running `i18nTextCollectorTask` and merge new content into the old afterward
3. Redact secrets (tx and GitHub tokens) from logged output

## Issue

- https://github.com/silverstripe/.github/issues/400