### PR TITLE
DEP Allow supported-modules ^2 for CMS 6 stuff

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "silverstripe/supported-modules": "^1",
+        "silverstripe/supported-modules": "^1 || ^2",
         "symfony/console": "^4 || ^5 || ^6 || ^7",
         "symfony/process": "^4 || ^5 || ^6 || ^7",
         "symfony/yaml": "^4 || ^5 || ^6 || ^7",


### PR DESCRIPTION
Adding dual-support here to match other deps, since this needs to work with CMS 5 as well.

## Issue

- https://github.com/silverstripe/.github/issues/407